### PR TITLE
track latest computed function call dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "start": "npm run lint && npm run build && npm run test",
     "lint": "eslint ./src ./test",
     "lint:fix": "eslint --fix ./src ./test",
-    "build": "rollup -c config/rollup.config.js && npm run build:handlers && npm run build:react && npm run build:classes && npm run build:websocket",
+    "build": "npm run build:core && npm run build:handlers && npm run build:react && npm run build:classes && npm run build:websocket",
+    "build:core": "rollup -c config/rollup.config.js",
     "build:handlers": "rollup -c config/rollup.handlers.config.js",
     "build:react": "rollup -c config/rollup.react.config.js",
     "build:classes": "rollup -c config/rollup.classes.config.js",
@@ -54,6 +55,7 @@
     ]
   },
   "devDependencies": {
+    "@babel/core": "^7.4.5",
     "@babel/preset-env": "^7.4.5",
     "@babel/preset-react": "^7.0.0",
     "@testing-library/react": "^8.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,27 +1,28 @@
 devDependencies:
-  '@babel/preset-env': 7.4.5
-  '@babel/preset-react': 7.0.0
-  '@testing-library/react': 8.0.1
-  '@types/jest': 24.0.13
-  babel-eslint: 10.0.1
-  babel-jest: 24.8.0
-  coveralls: 3.0.3
+  '@babel/core': 7.4.5
+  '@babel/preset-env': 7.4.5_@babel+core@7.4.5
+  '@babel/preset-react': 7.0.0_@babel+core@7.4.5
+  '@testing-library/react': 8.0.1_react-dom@16.8.6+react@16.8.6
+  '@types/jest': 24.0.14
+  babel-eslint: 10.0.1_eslint@5.16.0
+  babel-jest: 24.8.0_@babel+core@7.4.5
+  coveralls: 3.0.4
   eslint: 5.16.0
-  eslint-plugin-jest: 22.6.4
-  eslint-plugin-react: 7.13.0
+  eslint-plugin-jest: 22.6.4_eslint@5.16.0
+  eslint-plugin-react: 7.13.0_eslint@5.16.0
   jest: 24.8.0
   jest-dom: 3.5.0
   node-fetch: 2.6.0
-  normaliz: 0.1.1
+  normaliz: 0.1.2
   react: 16.8.6
-  react-dom: 16.8.6
-  react-test-renderer: 16.8.6
+  react-dom: 16.8.6_react@16.8.6
+  react-test-renderer: 16.8.6_react@16.8.6
   rimraf: 2.6.3
-  rollup: 1.13.0
-  rollup-plugin-terser: 5.0.0
+  rollup: 1.15.3
+  rollup-plugin-terser: 5.0.0_rollup@1.15.3
   wretch: 1.5.2
   ws: 7.0.0
-lockfileVersion: 5
+lockfileVersion: 5.1
 packages:
   /@babel/code-frame/7.0.0:
     dependencies:
@@ -42,7 +43,7 @@ packages:
       debug: 4.1.1
       json5: 2.1.0
       lodash: 4.17.11
-      resolve: 1.11.1
+      resolve: 1.11.0
       semver: 5.7.0
       source-map: 0.5.7
     dev: true
@@ -226,45 +227,50 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==
-  /@babel/plugin-proposal-async-generator-functions/7.2.0:
+  /@babel/plugin-proposal-async-generator-functions/7.2.0_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/helper-remap-async-to-generator': 7.1.0
-      '@babel/plugin-syntax-async-generators': 7.2.0
+      '@babel/plugin-syntax-async-generators': 7.2.0_@babel+core@7.4.5
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==
-  /@babel/plugin-proposal-json-strings/7.2.0:
+  /@babel/plugin-proposal-json-strings/7.2.0_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-plugin-utils': 7.0.0
-      '@babel/plugin-syntax-json-strings': 7.2.0
+      '@babel/plugin-syntax-json-strings': 7.2.0_@babel+core@7.4.5
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-MAFV1CA/YVmYwZG0fBQyXhmj0BHCB5egZHCKWIFVv/XCxAeVGIHfos3SwDck4LvCllENIAg7xMKOG5kH0dzyUg==
-  /@babel/plugin-proposal-object-rest-spread/7.4.4:
+  /@babel/plugin-proposal-object-rest-spread/7.4.4_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-plugin-utils': 7.0.0
-      '@babel/plugin-syntax-object-rest-spread': 7.2.0
+      '@babel/plugin-syntax-object-rest-spread': 7.2.0_@babel+core@7.4.5
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-dMBG6cSPBbHeEBdFXeQ2QLc5gUpg4Vkaz8octD4aoW/ISO+jBOcsuxYL7bsb5WSu8RLP6boxrBIALEHgoHtO9g==
-  /@babel/plugin-proposal-optional-catch-binding/7.2.0:
+  /@babel/plugin-proposal-optional-catch-binding/7.2.0_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-plugin-utils': 7.0.0
-      '@babel/plugin-syntax-optional-catch-binding': 7.2.0
+      '@babel/plugin-syntax-optional-catch-binding': 7.2.0_@babel+core@7.4.5
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==
-  /@babel/plugin-proposal-unicode-property-regex/7.4.4:
+  /@babel/plugin-proposal-unicode-property-regex/7.4.4_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/helper-regex': 7.4.4
       regexpu-core: 4.5.4
@@ -275,38 +281,33 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-j1NwnOqMG9mFUOH58JTFsA/+ZYzQLUZ/drqWUqxCYLGeu2JFZL8YrNC9hBxKmWtAuOCHPcRpgv7fhap09Fb4kA==
-  /@babel/plugin-syntax-async-generators/7.2.0:
+  /@babel/plugin-syntax-async-generators/7.2.0_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==
-  /@babel/plugin-syntax-json-strings/7.2.0:
+  /@babel/plugin-syntax-json-strings/7.2.0_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-5UGYnMSLRE1dqqZwug+1LISpA403HzlSfsg6P9VXU6TBjcSHeNlw4DxDx7LgpF+iKZoOG/+uzqoRHTdcUpiZNg==
-  /@babel/plugin-syntax-jsx/7.2.0:
+  /@babel/plugin-syntax-jsx/7.2.0_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-VyN4QANJkRW6lDBmENzRszvZf3/4AXaj9YR7GwrWeeN9tEBPuXbmDYVU9bYBN0D70zCWVwUy0HWq2553VCb6Hw==
-  /@babel/plugin-syntax-object-rest-spread/7.2.0:
-    dependencies:
-      '@babel/helper-plugin-utils': 7.0.0
-    dev: true
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==
   /@babel/plugin-syntax-object-rest-spread/7.2.0_@babel+core@7.4.5:
     dependencies:
       '@babel/core': 7.4.5
@@ -316,24 +317,27 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==
-  /@babel/plugin-syntax-optional-catch-binding/7.2.0:
+  /@babel/plugin-syntax-optional-catch-binding/7.2.0_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==
-  /@babel/plugin-transform-arrow-functions/7.2.0:
+  /@babel/plugin-transform-arrow-functions/7.2.0_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==
-  /@babel/plugin-transform-async-to-generator/7.4.4:
+  /@babel/plugin-transform-async-to-generator/7.4.4_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-module-imports': 7.0.0
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/helper-remap-async-to-generator': 7.1.0
@@ -342,16 +346,18 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-YiqW2Li8TXmzgbXw+STsSqPBPFnGviiaSp6CYOq55X8GQ2SGVLrXB6pNid8HkqkZAzOH6knbai3snhP7v0fNwA==
-  /@babel/plugin-transform-block-scoped-functions/7.2.0:
+  /@babel/plugin-transform-block-scoped-functions/7.2.0_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==
-  /@babel/plugin-transform-block-scoping/7.4.4:
+  /@babel/plugin-transform-block-scoping/7.4.4_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-plugin-utils': 7.0.0
       lodash: 4.17.11
     dev: true
@@ -359,8 +365,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-jkTUyWZcTrwxu5DD4rWz6rDB5Cjdmgz6z7M7RLXOJyCUkFBawssDGcGh8M/0FTSB87avyJI1HsTwUXp9nKA1PA==
-  /@babel/plugin-transform-classes/7.4.4:
+  /@babel/plugin-transform-classes/7.4.4_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-annotate-as-pure': 7.0.0
       '@babel/helper-define-map': 7.4.4
       '@babel/helper-function-name': 7.1.0
@@ -374,24 +381,27 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-/e44eFLImEGIpL9qPxSRat13I5QNRgBLu2hOQJCF7VLy/otSM/sypV1+XaIw5+502RX/+6YaSAPmldk+nhHDPw==
-  /@babel/plugin-transform-computed-properties/7.2.0:
+  /@babel/plugin-transform-computed-properties/7.2.0_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-kP/drqTxY6Xt3NNpKiMomfgkNn4o7+vKxK2DDKcBG9sHj51vHqMBGy8wbDS/J4lMxnqs153/T3+DmCEAkC5cpA==
-  /@babel/plugin-transform-destructuring/7.4.4:
+  /@babel/plugin-transform-destructuring/7.4.4_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-/aOx+nW0w8eHiEHm+BTERB2oJn5D127iye/SUQl7NjHy0lf+j7h4MKMMSOwdazGq9OxgiNADncE+SRJkCxjZpQ==
-  /@babel/plugin-transform-dotall-regex/7.4.4:
+  /@babel/plugin-transform-dotall-regex/7.4.4_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/helper-regex': 7.4.4
       regexpu-core: 4.5.4
@@ -402,16 +412,18 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==
-  /@babel/plugin-transform-duplicate-keys/7.2.0:
+  /@babel/plugin-transform-duplicate-keys/7.2.0_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-q+yuxW4DsTjNceUiTzK0L+AfQ0zD9rWaTLiUqHA8p0gxx7lu1EylenfzjeIWNkPy6e/0VG/Wjw9uf9LueQwLOw==
-  /@babel/plugin-transform-exponentiation-operator/7.2.0:
+  /@babel/plugin-transform-exponentiation-operator/7.2.0_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.1.0
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
@@ -419,16 +431,18 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==
-  /@babel/plugin-transform-for-of/7.4.4:
+  /@babel/plugin-transform-for-of/7.4.4_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==
-  /@babel/plugin-transform-function-name/7.4.4:
+  /@babel/plugin-transform-function-name/7.4.4_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-function-name': 7.1.0
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
@@ -436,24 +450,27 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==
-  /@babel/plugin-transform-literals/7.2.0:
+  /@babel/plugin-transform-literals/7.2.0_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-2ThDhm4lI4oV7fVQ6pNNK+sx+c/GM5/SaML0w/r4ZB7sAneD/piDJtwdKlNckXeyGK7wlwg2E2w33C/Hh+VFCg==
-  /@babel/plugin-transform-member-expression-literals/7.2.0:
+  /@babel/plugin-transform-member-expression-literals/7.2.0_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-HiU3zKkSU6scTidmnFJ0bMX8hz5ixC93b4MHMiYebmk2lUVNGOboPsqQvx5LzooihijUoLR/v7Nc1rbBtnc7FA==
-  /@babel/plugin-transform-modules-amd/7.2.0:
+  /@babel/plugin-transform-modules-amd/7.2.0_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-module-transforms': 7.4.4
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
@@ -461,8 +478,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-mK2A8ucqz1qhrdqjS9VMIDfIvvT2thrEsIQzbaTdc5QFzhDjQv2CkJJ5f6BXIkgbmaoax3zBr2RyvV/8zeoUZw==
-  /@babel/plugin-transform-modules-commonjs/7.4.4:
+  /@babel/plugin-transform-modules-commonjs/7.4.4_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-module-transforms': 7.4.4
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/helper-simple-access': 7.1.0
@@ -471,8 +489,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-4sfBOJt58sEo9a2BQXnZq+Q3ZTSAUXyK3E30o36BOGnJ+tvJ6YSxF0PG6kERvbeISgProodWuI9UVG3/FMY6iw==
-  /@babel/plugin-transform-modules-systemjs/7.4.4:
+  /@babel/plugin-transform-modules-systemjs/7.4.4_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-hoist-variables': 7.4.4
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
@@ -480,8 +499,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-MSiModfILQc3/oqnG7NrP1jHaSPryO6tA2kOMmAQApz5dayPxWiHqmq4sWH2xF5LcQK56LlbKByCd8Aah/OIkQ==
-  /@babel/plugin-transform-modules-umd/7.2.0:
+  /@babel/plugin-transform-modules-umd/7.2.0_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-module-transforms': 7.4.4
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
@@ -489,24 +509,27 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-BV3bw6MyUH1iIsGhXlOK6sXhmSarZjtJ/vMiD9dNmpY8QXFFQTj+6v92pcfy1iqa8DeAfJFwoxcrS/TUZda6sw==
-  /@babel/plugin-transform-named-capturing-groups-regex/7.4.5:
+  /@babel/plugin-transform-named-capturing-groups-regex/7.4.5_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       regexp-tree: 0.1.10
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-z7+2IsWafTBbjNsOxU/Iv5CvTJlr5w4+HGu1HovKYTtgJ362f7kBcQglkfmlspKKZ3bgrbSGvLfNx++ZJgCWsg==
-  /@babel/plugin-transform-new-target/7.4.4:
+  /@babel/plugin-transform-new-target/7.4.4_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-r1z3T2DNGQwwe2vPGZMBNjioT2scgWzK9BCnDEh+46z8EEwXBq24uRzd65I7pjtugzPSj921aM15RpESgzsSuA==
-  /@babel/plugin-transform-object-super/7.2.0:
+  /@babel/plugin-transform-object-super/7.2.0_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/helper-replace-supers': 7.4.4
     dev: true
@@ -514,8 +537,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-VMyhPYZISFZAqAPVkiYb7dUe2AsVi2/wCT5+wZdsNO31FojQJa9ns40hzZ6U9f50Jlq4w6qwzdBB2uwqZ00ebg==
-  /@babel/plugin-transform-parameters/7.4.4:
+  /@babel/plugin-transform-parameters/7.4.4_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-call-delegate': 7.4.4
       '@babel/helper-get-function-arity': 7.0.0
       '@babel/helper-plugin-utils': 7.0.0
@@ -524,84 +548,94 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==
-  /@babel/plugin-transform-property-literals/7.2.0:
+  /@babel/plugin-transform-property-literals/7.2.0_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-9q7Dbk4RhgcLp8ebduOpCbtjh7C0itoLYHXd9ueASKAG/is5PQtMR5VJGka9NKqGhYEGn5ITahd4h9QeBMylWQ==
-  /@babel/plugin-transform-react-display-name/7.2.0:
+  /@babel/plugin-transform-react-display-name/7.2.0_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-Htf/tPa5haZvRMiNSQSFifK12gtr/8vwfr+A9y69uF0QcU77AVu4K7MiHEkTxF7lQoHOL0F9ErqgfNEAKgXj7A==
-  /@babel/plugin-transform-react-jsx-self/7.2.0:
+  /@babel/plugin-transform-react-jsx-self/7.2.0_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-plugin-utils': 7.0.0
-      '@babel/plugin-syntax-jsx': 7.2.0
+      '@babel/plugin-syntax-jsx': 7.2.0_@babel+core@7.4.5
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-v6S5L/myicZEy+jr6ielB0OR8h+EH/1QFx/YJ7c7Ua+7lqsjj/vW6fD5FR9hB/6y7mGbfT4vAURn3xqBxsUcdg==
-  /@babel/plugin-transform-react-jsx-source/7.2.0:
+  /@babel/plugin-transform-react-jsx-source/7.2.0_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-plugin-utils': 7.0.0
-      '@babel/plugin-syntax-jsx': 7.2.0
+      '@babel/plugin-syntax-jsx': 7.2.0_@babel+core@7.4.5
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-A32OkKTp4i5U6aE88GwwcuV4HAprUgHcTq0sSafLxjr6AW0QahrCRCjxogkbbcdtpbXkuTOlgpjophCxb6sh5g==
-  /@babel/plugin-transform-react-jsx/7.3.0:
+  /@babel/plugin-transform-react-jsx/7.3.0_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-builder-react-jsx': 7.3.0
       '@babel/helper-plugin-utils': 7.0.0
-      '@babel/plugin-syntax-jsx': 7.2.0
+      '@babel/plugin-syntax-jsx': 7.2.0_@babel+core@7.4.5
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-a/+aRb7R06WcKvQLOu4/TpjKOdvVEKRLWFpKcNuHhiREPgGRB4TQJxq07+EZLS8LFVYpfq1a5lDUnuMdcCpBKg==
-  /@babel/plugin-transform-regenerator/7.4.5:
+  /@babel/plugin-transform-regenerator/7.4.5_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       regenerator-transform: 0.14.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-gBKRh5qAaCWntnd09S8QC7r3auLCqq5DI6O0DlfoyDjslSBVqBibrMdsqO+Uhmx3+BlOmE/Kw1HFxmGbv0N9dA==
-  /@babel/plugin-transform-reserved-words/7.2.0:
+  /@babel/plugin-transform-reserved-words/7.2.0_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-fz43fqW8E1tAB3DKF19/vxbpib1fuyCwSPE418ge5ZxILnBhWyhtPgz8eh1RCGGJlwvksHkyxMxh0eenFi+kFw==
-  /@babel/plugin-transform-shorthand-properties/7.2.0:
+  /@babel/plugin-transform-shorthand-properties/7.2.0_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-QP4eUM83ha9zmYtpbnyjTLAGKQritA5XW/iG9cjtuOI8s1RuL/3V6a3DeSHfKutJQ+ayUfeZJPcnCYEQzaPQqg==
-  /@babel/plugin-transform-spread/7.2.2:
+  /@babel/plugin-transform-spread/7.2.2_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==
-  /@babel/plugin-transform-sticky-regex/7.2.0:
+  /@babel/plugin-transform-sticky-regex/7.2.0_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/helper-regex': 7.4.4
     dev: true
@@ -609,8 +643,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-KKYCoGaRAf+ckH8gEL3JHUaFVyNHKe3ASNsZ+AlktgHevvxGigoIttrEJb8iKN03Q7Eazlv1s6cx2B2cQ3Jabw==
-  /@babel/plugin-transform-template-literals/7.4.4:
+  /@babel/plugin-transform-template-literals/7.4.4_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-annotate-as-pure': 7.0.0
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
@@ -618,16 +653,18 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==
-  /@babel/plugin-transform-typeof-symbol/7.2.0:
+  /@babel/plugin-transform-typeof-symbol/7.2.0_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-2LNhETWYxiYysBtrBTqL8+La0jIoQQnIScUJc74OYvUGRmkskNY4EzLCnjHBzdmb38wqtTaixpo1NctEcvMDZw==
-  /@babel/plugin-transform-unicode-regex/7.4.4:
+  /@babel/plugin-transform-unicode-regex/7.4.4_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/helper-regex': 7.4.4
       regexpu-core: 4.5.4
@@ -636,50 +673,51 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-il+/XdNw01i93+M9J9u4T7/e/Ue/vWfNZE4IRUQjplu2Mqb/AFTDimkw2tdEdSH50wuQXZAbXSql0UphQke+vA==
-  /@babel/preset-env/7.4.5:
+  /@babel/preset-env/7.4.5_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-module-imports': 7.0.0
       '@babel/helper-plugin-utils': 7.0.0
-      '@babel/plugin-proposal-async-generator-functions': 7.2.0
-      '@babel/plugin-proposal-json-strings': 7.2.0
-      '@babel/plugin-proposal-object-rest-spread': 7.4.4
-      '@babel/plugin-proposal-optional-catch-binding': 7.2.0
-      '@babel/plugin-proposal-unicode-property-regex': 7.4.4
-      '@babel/plugin-syntax-async-generators': 7.2.0
-      '@babel/plugin-syntax-json-strings': 7.2.0
-      '@babel/plugin-syntax-object-rest-spread': 7.2.0
-      '@babel/plugin-syntax-optional-catch-binding': 7.2.0
-      '@babel/plugin-transform-arrow-functions': 7.2.0
-      '@babel/plugin-transform-async-to-generator': 7.4.4
-      '@babel/plugin-transform-block-scoped-functions': 7.2.0
-      '@babel/plugin-transform-block-scoping': 7.4.4
-      '@babel/plugin-transform-classes': 7.4.4
-      '@babel/plugin-transform-computed-properties': 7.2.0
-      '@babel/plugin-transform-destructuring': 7.4.4
-      '@babel/plugin-transform-dotall-regex': 7.4.4
-      '@babel/plugin-transform-duplicate-keys': 7.2.0
-      '@babel/plugin-transform-exponentiation-operator': 7.2.0
-      '@babel/plugin-transform-for-of': 7.4.4
-      '@babel/plugin-transform-function-name': 7.4.4
-      '@babel/plugin-transform-literals': 7.2.0
-      '@babel/plugin-transform-member-expression-literals': 7.2.0
-      '@babel/plugin-transform-modules-amd': 7.2.0
-      '@babel/plugin-transform-modules-commonjs': 7.4.4
-      '@babel/plugin-transform-modules-systemjs': 7.4.4
-      '@babel/plugin-transform-modules-umd': 7.2.0
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.4.5
-      '@babel/plugin-transform-new-target': 7.4.4
-      '@babel/plugin-transform-object-super': 7.2.0
-      '@babel/plugin-transform-parameters': 7.4.4
-      '@babel/plugin-transform-property-literals': 7.2.0
-      '@babel/plugin-transform-regenerator': 7.4.5
-      '@babel/plugin-transform-reserved-words': 7.2.0
-      '@babel/plugin-transform-shorthand-properties': 7.2.0
-      '@babel/plugin-transform-spread': 7.2.2
-      '@babel/plugin-transform-sticky-regex': 7.2.0
-      '@babel/plugin-transform-template-literals': 7.4.4
-      '@babel/plugin-transform-typeof-symbol': 7.2.0
-      '@babel/plugin-transform-unicode-regex': 7.4.4
+      '@babel/plugin-proposal-async-generator-functions': 7.2.0_@babel+core@7.4.5
+      '@babel/plugin-proposal-json-strings': 7.2.0_@babel+core@7.4.5
+      '@babel/plugin-proposal-object-rest-spread': 7.4.4_@babel+core@7.4.5
+      '@babel/plugin-proposal-optional-catch-binding': 7.2.0_@babel+core@7.4.5
+      '@babel/plugin-proposal-unicode-property-regex': 7.4.4_@babel+core@7.4.5
+      '@babel/plugin-syntax-async-generators': 7.2.0_@babel+core@7.4.5
+      '@babel/plugin-syntax-json-strings': 7.2.0_@babel+core@7.4.5
+      '@babel/plugin-syntax-object-rest-spread': 7.2.0_@babel+core@7.4.5
+      '@babel/plugin-syntax-optional-catch-binding': 7.2.0_@babel+core@7.4.5
+      '@babel/plugin-transform-arrow-functions': 7.2.0_@babel+core@7.4.5
+      '@babel/plugin-transform-async-to-generator': 7.4.4_@babel+core@7.4.5
+      '@babel/plugin-transform-block-scoped-functions': 7.2.0_@babel+core@7.4.5
+      '@babel/plugin-transform-block-scoping': 7.4.4_@babel+core@7.4.5
+      '@babel/plugin-transform-classes': 7.4.4_@babel+core@7.4.5
+      '@babel/plugin-transform-computed-properties': 7.2.0_@babel+core@7.4.5
+      '@babel/plugin-transform-destructuring': 7.4.4_@babel+core@7.4.5
+      '@babel/plugin-transform-dotall-regex': 7.4.4_@babel+core@7.4.5
+      '@babel/plugin-transform-duplicate-keys': 7.2.0_@babel+core@7.4.5
+      '@babel/plugin-transform-exponentiation-operator': 7.2.0_@babel+core@7.4.5
+      '@babel/plugin-transform-for-of': 7.4.4_@babel+core@7.4.5
+      '@babel/plugin-transform-function-name': 7.4.4_@babel+core@7.4.5
+      '@babel/plugin-transform-literals': 7.2.0_@babel+core@7.4.5
+      '@babel/plugin-transform-member-expression-literals': 7.2.0_@babel+core@7.4.5
+      '@babel/plugin-transform-modules-amd': 7.2.0_@babel+core@7.4.5
+      '@babel/plugin-transform-modules-commonjs': 7.4.4_@babel+core@7.4.5
+      '@babel/plugin-transform-modules-systemjs': 7.4.4_@babel+core@7.4.5
+      '@babel/plugin-transform-modules-umd': 7.2.0_@babel+core@7.4.5
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.4.5_@babel+core@7.4.5
+      '@babel/plugin-transform-new-target': 7.4.4_@babel+core@7.4.5
+      '@babel/plugin-transform-object-super': 7.2.0_@babel+core@7.4.5
+      '@babel/plugin-transform-parameters': 7.4.4_@babel+core@7.4.5
+      '@babel/plugin-transform-property-literals': 7.2.0_@babel+core@7.4.5
+      '@babel/plugin-transform-regenerator': 7.4.5_@babel+core@7.4.5
+      '@babel/plugin-transform-reserved-words': 7.2.0_@babel+core@7.4.5
+      '@babel/plugin-transform-shorthand-properties': 7.2.0_@babel+core@7.4.5
+      '@babel/plugin-transform-spread': 7.2.2_@babel+core@7.4.5
+      '@babel/plugin-transform-sticky-regex': 7.2.0_@babel+core@7.4.5
+      '@babel/plugin-transform-template-literals': 7.4.4_@babel+core@7.4.5
+      '@babel/plugin-transform-typeof-symbol': 7.2.0_@babel+core@7.4.5
+      '@babel/plugin-transform-unicode-regex': 7.4.4_@babel+core@7.4.5
       '@babel/types': 7.4.4
       browserslist: 4.6.2
       core-js-compat: 3.1.3
@@ -691,13 +729,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-f2yNVXM+FsR5V8UwcFeIHzHWgnhXg3NpRmy0ADvALpnhB0SLbCvrCRr4BLOUYbQNLS+Z0Yer46x9dJXpXewI7w==
-  /@babel/preset-react/7.0.0:
+  /@babel/preset-react/7.0.0_@babel+core@7.4.5:
     dependencies:
+      '@babel/core': 7.4.5
       '@babel/helper-plugin-utils': 7.0.0
-      '@babel/plugin-transform-react-display-name': 7.2.0
-      '@babel/plugin-transform-react-jsx': 7.3.0
-      '@babel/plugin-transform-react-jsx-self': 7.2.0
-      '@babel/plugin-transform-react-jsx-source': 7.2.0
+      '@babel/plugin-transform-react-display-name': 7.2.0_@babel+core@7.4.5
+      '@babel/plugin-transform-react-jsx': 7.3.0_@babel+core@7.4.5
+      '@babel/plugin-transform-react-jsx-self': 7.2.0_@babel+core@7.4.5
+      '@babel/plugin-transform-react-jsx-source': 7.2.0_@babel+core@7.4.5
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -772,7 +811,7 @@ packages:
       graceful-fs: 4.1.15
       jest-changed-files: 24.8.0
       jest-config: 24.8.0
-      jest-haste-map: 24.8.0
+      jest-haste-map: 24.8.1
       jest-message-util: 24.8.0
       jest-regex-util: 24.3.0
       jest-resolve-dependencies: 24.8.0
@@ -828,7 +867,7 @@ packages:
       istanbul-lib-report: 2.0.8
       istanbul-lib-source-maps: 3.0.6
       istanbul-reports: 2.2.6
-      jest-haste-map: 24.8.0
+      jest-haste-map: 24.8.1
       jest-resolve: 24.8.0_jest-resolve@24.8.0
       jest-runtime: 24.8.0
       jest-util: 24.8.0
@@ -865,7 +904,7 @@ packages:
   /@jest/test-sequencer/24.8.0:
     dependencies:
       '@jest/test-result': 24.8.0
-      jest-haste-map: 24.8.0
+      jest-haste-map: 24.8.1
       jest-runner: 24.8.0
       jest-runtime: 24.8.0
     dev: true
@@ -882,7 +921,7 @@ packages:
       convert-source-map: 1.6.0
       fast-json-stable-stringify: 2.0.0
       graceful-fs: 4.1.15
-      jest-haste-map: 24.8.0
+      jest-haste-map: 24.8.1
       jest-regex-util: 24.3.0
       jest-util: 24.8.0
       micromatch: 3.1.10
@@ -909,21 +948,24 @@ packages:
     dev: true
     resolution:
       integrity: sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==
-  /@testing-library/dom/5.1.1:
+  /@testing-library/dom/5.2.0:
     dependencies:
       '@babel/runtime': 7.4.5
       '@sheerun/mutationobserver-shim': 0.3.2
+      aria-query: 3.0.0
       pretty-format: 24.8.0
       wait-for-expect: 1.2.0
     dev: true
     engines:
       node: '>=8'
     resolution:
-      integrity: sha512-twpAkqomsI0xeOLehijOAmPxeKvs6+WZC/6/nXD0+HNQupP3OZeZho/PBlNhrGL+8nQWiPjdvmxeyU0tq+hctA==
-  /@testing-library/react/8.0.1:
+      integrity: sha512-nFaZes/bzDfMqwZpQXdiPyj3WXU16FYf5k5NCFu/qJM4JdRJLHEtSRYtrETmk7nCf+qLVoHCqRduGi/4KE83Gw==
+  /@testing-library/react/8.0.1_react-dom@16.8.6+react@16.8.6:
     dependencies:
       '@babel/runtime': 7.4.5
-      '@testing-library/dom': 5.1.1
+      '@testing-library/dom': 5.2.0
+      react: 16.8.6
+      react-dom: 16.8.6_react@16.8.6
     dev: true
     engines:
       node: '>=8'
@@ -938,7 +980,7 @@ packages:
       '@babel/types': 7.4.4
       '@types/babel__generator': 7.0.2
       '@types/babel__template': 7.0.2
-      '@types/babel__traverse': 7.0.6
+      '@types/babel__traverse': 7.0.7
     dev: true
     resolution:
       integrity: sha512-cfCCrFmiGY/yq0NuKNxIQvZFy9kY/1immpSpTngOnyIbD4+eJOG5mxphhHDv3CHL9GltO4GcKr54kGBg3RNdbg==
@@ -955,12 +997,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==
-  /@types/babel__traverse/7.0.6:
+  /@types/babel__traverse/7.0.7:
     dependencies:
       '@babel/types': 7.4.4
     dev: true
     resolution:
-      integrity: sha512-XYVgHF2sQ0YblLRMLNPB3CkFMewzFmlDsH/TneZFHUXDlABQgh88uOxuez7ZcXxayLFrqLwtDH1t+FmlFwNZxw==
+      integrity: sha512-CeBpmX1J8kWLcDEnI3Cl2Eo6RfbGvzUctA+CjZUhOKDFbLfcr7fc4usEqLNWetrlJd7RhAkyYe2czXop4fICpw==
   /@types/estree/0.0.39:
     dev: true
     resolution:
@@ -986,16 +1028,16 @@ packages:
     dev: true
     resolution:
       integrity: sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==
-  /@types/jest/24.0.13:
+  /@types/jest/24.0.14:
     dependencies:
       '@types/jest-diff': 20.0.1
     dev: true
     resolution:
-      integrity: sha512-3m6RPnO35r7Dg+uMLj1+xfZaOgIHHHut61djNjzwExXN4/Pm9has9C6I1KMYSfz7mahDhWUOVg4HW/nZdv5Pww==
-  /@types/node/12.0.4:
+      integrity: sha512-IxS2AO0nOr4zrpKfRCxobQUb1bSK6ejodZ7odCzHXMjsASCI8J10N8qVQhrCjvJTc3bUjGGeuD+ytKZqyhajqQ==
+  /@types/node/12.0.8:
     dev: true
     resolution:
-      integrity: sha512-j8YL2C0fXq7IONwl/Ud5Kt0PeXw22zGERt+HSSnwbKOJVsAGkEz3sFCYwaF9IOuoG1HOtE0vKCj6sXF7Q0+Vaw==
+      integrity: sha512-b8bbUOTwzIY3V5vDTY1fIJ+ePKDUBqt2hC2woVGotdQQhG/2Sh62HOKHrT7ab+VerXAcPyAiTEipPu/FsreUtg==
   /@types/stack-utils/1.0.1:
     dev: true
     resolution:
@@ -1097,6 +1139,13 @@ packages:
     dev: true
     resolution:
       integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
+  /aria-query/3.0.0:
+    dependencies:
+      ast-types-flow: 0.0.7
+      commander: 2.20.0
+    dev: true
+    resolution:
+      integrity: sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=
   /arr-diff/4.0.0:
     dev: true
     engines:
@@ -1152,6 +1201,10 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
+  /ast-types-flow/0.0.7:
+    dev: true
+    resolution:
+      integrity: sha1-9wtzXGvKGlycItmCw+Oef+ujva0=
   /astral-regex/1.0.0:
     dev: true
     engines:
@@ -1181,12 +1234,13 @@ packages:
     dev: true
     resolution:
       integrity: sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
-  /babel-eslint/10.0.1:
+  /babel-eslint/10.0.1_eslint@5.16.0:
     dependencies:
       '@babel/code-frame': 7.0.0
       '@babel/parser': 7.4.5
       '@babel/traverse': 7.4.5
       '@babel/types': 7.4.4
+      eslint: 5.16.0
       eslint-scope: 3.7.1
       eslint-visitor-keys: 1.0.0
     dev: true
@@ -1196,22 +1250,6 @@ packages:
       eslint: '>= 4.12.1'
     resolution:
       integrity: sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==
-  /babel-jest/24.8.0:
-    dependencies:
-      '@jest/transform': 24.8.0
-      '@jest/types': 24.8.0
-      '@types/babel__core': 7.1.2
-      babel-plugin-istanbul: 5.1.4
-      babel-preset-jest: 24.6.0
-      chalk: 2.4.2
-      slash: 2.0.0
-    dev: true
-    engines:
-      node: '>= 6'
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    resolution:
-      integrity: sha512-+5/kaZt4I9efoXzPlZASyK/lN9qdRKmmUav9smVc0ruPQD7IsfucQ87gpOE8mn2jbDuS6M/YOW6n3v9ZoIfgnw==
   /babel-jest/24.8.0_@babel+core@7.4.5:
     dependencies:
       '@babel/core': 7.4.5
@@ -1241,23 +1279,12 @@ packages:
       integrity: sha512-dySz4VJMH+dpndj0wjJ8JPs/7i1TdSPb1nRrn56/92pKOF9VKC1FMFJmMXjzlGGusnCAqujP6PBCiKq0sVA+YQ==
   /babel-plugin-jest-hoist/24.6.0:
     dependencies:
-      '@types/babel__traverse': 7.0.6
+      '@types/babel__traverse': 7.0.7
     dev: true
     engines:
       node: '>= 6'
     resolution:
       integrity: sha512-3pKNH6hMt9SbOv0F3WVmy5CWQ4uogS3k0GY5XLyQHJ9EGpAT9XWkFd2ZiXXtkwFHdAHa5j7w7kfxSP5lAIwu7w==
-  /babel-preset-jest/24.6.0:
-    dependencies:
-      '@babel/plugin-syntax-object-rest-spread': 7.2.0
-      babel-plugin-jest-hoist: 24.6.0
-    dev: true
-    engines:
-      node: '>= 6'
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    resolution:
-      integrity: sha512-pdZqLEdmy1ZK5kyRUfvBb2IfTPb2BUvIJczlPspS8fWmBQslNNDBqVfh7BW5leOVJMDZKzjD8XEyABTk6gQ5yw==
   /babel-preset-jest/24.6.0_@babel+core@7.4.5:
     dependencies:
       '@babel/core': 7.4.5
@@ -1331,7 +1358,7 @@ packages:
   /browserslist/4.6.2:
     dependencies:
       caniuse-lite: 1.0.30000974
-      electron-to-chromium: 1.3.152
+      electron-to-chromium: 1.3.158
       node-releases: 1.1.23
     dev: true
     hasBin: true
@@ -1521,7 +1548,7 @@ packages:
     dev: true
     resolution:
       integrity: sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
-  /coveralls/3.0.3:
+  /coveralls/3.0.4:
     dependencies:
       growl: 1.10.5
       js-yaml: 3.13.1
@@ -1534,7 +1561,7 @@ packages:
       node: '>=4.0.0'
     hasBin: true
     resolution:
-      integrity: sha512-viNfeGlda2zJr8Gj1zqXpDMRjw9uM54p7wzZdvLRyOgnAfCe974Dq4veZkjJdxQXbmdppu6flEajFYseHYaUhg==
+      integrity: sha512-eyqUWA/7RT0JagiL0tThVhjbIjoiEUyWCjtUJoOPcWoeofP5WK/jb2OJYoBFrR6DvplR+AxOyuBqk4JHkk5ykA==
   /cross-spawn/6.0.5:
     dependencies:
       nice-try: 1.0.5
@@ -1694,10 +1721,10 @@ packages:
     dev: true
     resolution:
       integrity: sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=
-  /electron-to-chromium/1.3.152:
+  /electron-to-chromium/1.3.158:
     dev: true
     resolution:
-      integrity: sha512-Ah10cGMWIXYD8aUTH2Y7lGRhaOFQLyWuxvXmCPCZCbUIGJ4swnNmT6P4aA8RTgUmNw9kmcDL6SoU8TZC4YuZGg==
+      integrity: sha512-wJsJaWsViNQ129XPGmyO5gGs1jPMHr9vffjHAhUje1xZbEzQcqbENdvfyRD9q8UF0TgFQFCCUbaIpJarFbvsIg==
   /emoji-regex/7.0.3:
     dev: true
     resolution:
@@ -1757,7 +1784,9 @@ packages:
       source-map: 0.6.1
     resolution:
       integrity: sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==
-  /eslint-plugin-jest/22.6.4:
+  /eslint-plugin-jest/22.6.4_eslint@5.16.0:
+    dependencies:
+      eslint: 5.16.0
     dev: true
     engines:
       node: '>=6'
@@ -1765,10 +1794,11 @@ packages:
       eslint: '>=5'
     resolution:
       integrity: sha512-36OqnZR/uMCDxXGmTsqU4RwllR0IiB/XF8GW3ODmhsjiITKuI0GpgultWFt193ipN3HARkaIcKowpE6HBvRHNg==
-  /eslint-plugin-react/7.13.0:
+  /eslint-plugin-react/7.13.0_eslint@5.16.0:
     dependencies:
       array-includes: 3.0.3
       doctrine: 2.1.0
+      eslint: 5.16.0
       has: 1.0.3
       jsx-ast-utils: 2.1.0
       object.fromentries: 2.0.0
@@ -2762,7 +2792,7 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-RR4fo8jEmMD9zSz2nLbs2j0zvPpk/KCEz3a62jJWbd2ayNo0cb+KFRxPHVhE4ZmgGJEQp0fosmNz84IfqM8cMQ==
-  /jest-haste-map/24.8.0:
+  /jest-haste-map/24.8.1:
     dependencies:
       '@jest/types': 24.8.0
       anymatch: 2.0.0
@@ -2781,7 +2811,7 @@ packages:
     optionalDependencies:
       fsevents: 1.2.9
     resolution:
-      integrity: sha512-ZBPRGHdPt1rHajWelXdqygIDpJx8u3xOoLyUBWRW28r3tagrgoepPrzAozW7kW9HrQfhvmiv1tncsxqHJO1onQ==
+      integrity: sha512-SwaxMGVdAZk3ernAx2Uv2sorA7jm3Kx+lR0grp6rMmnY06Kn/urtKx1LPN2mGTea4fCT38impYT28FfcLUhX0g==
   /jest-jasmine2/24.8.0:
     dependencies:
       '@babel/traverse': 7.4.5
@@ -2898,7 +2928,7 @@ packages:
       graceful-fs: 4.1.15
       jest-config: 24.8.0
       jest-docblock: 24.3.0
-      jest-haste-map: 24.8.0
+      jest-haste-map: 24.8.1
       jest-jasmine2: 24.8.0
       jest-leak-detector: 24.8.0
       jest-message-util: 24.8.0
@@ -2926,7 +2956,7 @@ packages:
       glob: 7.1.4
       graceful-fs: 4.1.15
       jest-config: 24.8.0
-      jest-haste-map: 24.8.0
+      jest-haste-map: 24.8.1
       jest-message-util: 24.8.0
       jest-mock: 24.8.0
       jest-regex-util: 24.3.0
@@ -3075,7 +3105,7 @@ packages:
       request: 2.88.0
       request-promise-native: 1.0.7_request@2.88.0
       sax: 1.2.4
-      symbol-tree: 3.2.2
+      symbol-tree: 3.2.4
       tough-cookie: 2.5.0
       w3c-hr-time: 1.0.1
       webidl-conversions: 4.0.2
@@ -3466,14 +3496,14 @@ packages:
     dev: true
     resolution:
       integrity: sha512-uq1iL79YjfYC0WXoHbC/z28q/9pOl8kSHaXdWmAAc8No+bDwqkZbzIJz55g/MUsPgSGm9LZ7QSUbzTcH5tz47w==
-  /normaliz/0.1.1:
+  /normaliz/0.1.2:
     dev: true
     resolution:
-      integrity: sha512-UstTcJRTNGlXIILJSOQzj2MRF6/qcfVu4dB0neoilffb7taT5/z1XF612q5T4z+95V7epcljFMRS1YNULpf5vQ==
+      integrity: sha512-1krwic/Ax6btssYLaD9Qiy01c8cYYKO7LNz579i217ciF569xYdrmRHjAjMteJlmdihxl/LZjWbUCS9JhrS0Xw==
   /normalize-package-data/2.5.0:
     dependencies:
       hosted-git-info: 2.7.1
-      resolve: 1.11.1
+      resolve: 1.11.0
       semver: 5.7.0
       validate-npm-package-license: 3.0.4
     dev: true
@@ -3851,11 +3881,12 @@ packages:
       node: '>=0.6'
     resolution:
       integrity: sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
-  /react-dom/16.8.6:
+  /react-dom/16.8.6_react@16.8.6:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       prop-types: 15.7.2
+      react: 16.8.6
       scheduler: 0.13.6
     dev: true
     peerDependencies:
@@ -3866,10 +3897,11 @@ packages:
     dev: true
     resolution:
       integrity: sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
-  /react-test-renderer/16.8.6:
+  /react-test-renderer/16.8.6_react@16.8.6:
     dependencies:
       object-assign: 4.1.1
       prop-types: 15.7.2
+      react: 16.8.6
       react-is: 16.8.6
       scheduler: 0.13.6
     dev: true
@@ -4117,12 +4149,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==
-  /resolve/1.11.1:
-    dependencies:
-      path-parse: 1.0.6
-    dev: true
-    resolution:
-      integrity: sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==
   /restore-cursor/2.0.0:
     dependencies:
       onetime: 2.0.1
@@ -4145,10 +4171,11 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
-  /rollup-plugin-terser/5.0.0:
+  /rollup-plugin-terser/5.0.0_rollup@1.15.3:
     dependencies:
       '@babel/code-frame': 7.0.0
       jest-worker: 24.6.0
+      rollup: 1.15.3
       serialize-javascript: 1.7.0
       terser: 4.0.0
     dev: true
@@ -4156,15 +4183,15 @@ packages:
       rollup: '>=0.66.0 <2'
     resolution:
       integrity: sha512-W+jJ4opYnlmNyVW0vtRufs+EGf68BIJ7bnOazgz8mgz8pA9lUyrEifAhPs5y9M16wFeAyBGaRjKip4dnFBtXaw==
-  /rollup/1.13.0:
+  /rollup/1.15.3:
     dependencies:
       '@types/estree': 0.0.39
-      '@types/node': 12.0.4
+      '@types/node': 12.0.8
       acorn: 6.1.1
     dev: true
     hasBin: true
     resolution:
-      integrity: sha512-pW4G4cQmtEmbg4/CoFYc2AYeKiGpMAVak7kFpch1UJnYkXMn/34L8cD0kxkmjJNpJ/NagOHVdCwdkbtCEuDEww==
+      integrity: sha512-u2TVHLE/iUvFNAVSQb2DT6XEydOkgEHGLoRnY4jKJiZR/lmhqOM+ofGwSVbHhysZheAakqIa7B/3gChoK9VY0w==
   /rsvp/4.8.5:
     dev: true
     engines:
@@ -4181,7 +4208,7 @@ packages:
       integrity: sha1-A3GrSuC91yDUFm19/aZP96RFpsA=
   /rxjs/6.5.2:
     dependencies:
-      tslib: 1.9.3
+      tslib: 1.10.0
     dev: true
     engines:
       npm: '>=2.0.0'
@@ -4557,10 +4584,10 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
-  /symbol-tree/3.2.2:
+  /symbol-tree/3.2.4:
     dev: true
     resolution:
-      integrity: sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=
+      integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
   /table/5.4.0:
     dependencies:
       ajv: 6.10.0
@@ -4682,10 +4709,10 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
-  /tslib/1.9.3:
+  /tslib/1.10.0:
     dev: true
     resolution:
-      integrity: sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
+      integrity: sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
   /tunnel-agent/0.6.0:
     dependencies:
       safe-buffer: 5.1.2
@@ -4956,6 +4983,7 @@ packages:
     resolution:
       integrity: sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==
 specifiers:
+  '@babel/core': ^7.4.5
   '@babel/preset-env': ^7.4.5
   '@babel/preset-react': ^7.0.0
   '@testing-library/react': ^8.0.1

--- a/src/computed.js
+++ b/src/computed.js
@@ -1,11 +1,13 @@
 import { data } from './data'
-const { computedStack } = data
+const { computedStack, computedDependenciesTracker } = data
 
 export function computed(wrappedFunction, { autoRun = true, callback, bind } = {}) {
     // Proxify the function in order to intercept the calls
     const proxy = new Proxy(wrappedFunction, {
         apply(target, thisArg, argsList) {
             function observeComputation(fun) {
+                // Track object and object properties accessed during this function call
+                computedDependenciesTracker.set(callback || proxy, new WeakMap())
                 // Store into the stack a reference to the computed function
                 computedStack.unshift(callback || proxy)
                 // Run the computed function - or the async function

--- a/src/data.js
+++ b/src/data.js
@@ -1,4 +1,5 @@
 export const data = {
     computedStack: [],
-    observersMap: new WeakMap()
+    observersMap: new WeakMap(),
+    computedDependenciesTracker: new WeakMap()
 }

--- a/src/dispose.js
+++ b/src/dispose.js
@@ -1,2 +1,7 @@
+import { data } from './data'
+
 // The disposed flag which is used to remove a computed function reference pointer
-export function dispose(_) { return _.__disposed = true }
+export function dispose(computedFunction) {
+    data.computedDependenciesTracker.delete(computedFunction)
+    return computedFunction.__disposed = true
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -428,3 +428,34 @@ test('bind computed functions using the bind option', () => {
     obj.a = 2
     expect(obj.sum).toBe(4)
 })
+
+test('eliminate unused function dependencies', () => {
+    const observed = observe({
+        condition: true,
+        a: 0,
+        b: 0
+    })
+
+    const object = {
+        counter: 0
+    }
+
+    computed(() => {
+        if(observed.condition) {
+            observed.a++
+        } else {
+            observed.b++
+        }
+        object.counter++
+    })
+
+    expect(object.counter).toBe(1)
+    observed.a++
+    expect(object.counter).toBe(2)
+    observed.condition = false
+    expect(object.counter).toBe(3)
+    observed.a++
+    expect(object.counter).toBe(3)
+    observed.b++
+    expect(object.counter).toBe(4)
+})


### PR DESCRIPTION
Should solve issue #10 by keeping weak references to observed objects and properties used during the latest run of a computed function