### PR TITLE
Let cellx release its global pendingCells array between benchmarks

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -4,5 +4,5 @@ _Adapted from: https://github.com/maverick-js/observables/tree/main/bench_
 
 ```bash
 npm i
-env NODE_OPTIONS="--max-old-space-size=8096" npm start
+npm start
 ```

--- a/bench/layers.mjs
+++ b/bench/layers.mjs
@@ -64,6 +64,9 @@ async function main() {
         }
         runs.push(await start(current.fn, layers))
       }
+      // Allow libraries that free resources asynchronously (e.g. cellx) do so.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
       if(typeof result !== 'number') {
         current.runs[i] = result
       } else {


### PR DESCRIPTION
This pull request ports to this repository's context the changes I originally proposed to the maverick-js benchmark (see https://github.com/maverick-js/observables/pull/8).

On my machine running the benchmark crashed due to Node.js running out of memory. Turns out that cellx uses a global pendingCells array that's filled during processing and is released asynchronously in batches. In the 2500 tier the amount of memory retained by cellx tended to become over 4 gigabytes. It also made things a bit unfair for libraries benchmarked after cellx, as they had to deal with the bloated heap.

This pull request adds a small setTimeout(..., 0) breather between different benchmarks. This lets cellx return the memory to the GC pool between benchmark runs. The reduced memory bloat also allows to remove the `--max-old-space-size=8096` parameter passed to node (at least on my machine).