### PR TITLE
fix: add a disposal phase for the cellx benchmark

### DIFF
--- a/bench/layers.mjs
+++ b/bench/layers.mjs
@@ -176,6 +176,11 @@ function runCellx(layers, done) {
   const solution = [end.a.get(), end.b.get(), end.c.get(), end.d.get()]
   const endTime = performance.now() - startTime
 
+  start.a.dispose();
+  start.b.dispose();
+  start.c.dispose();
+  start.d.dispose();
+
   done(isSolution(layers, solution) ? endTime : 'wrong')
 }
 


### PR DESCRIPTION
This pull request is continuation for #27. Now that the number of runs per tier has been bumped to 100, cellx is still trashing the JS heap.

This pull request alleviates the problem by explicitly disposing the root cells after each cellx run. It's not exactly fair towards the other libraries to give special care and attention for cellx in this manner, but it's skewing the results for the libraries following it. For example (on my machine, ymmv) hyperactiv performs much better in the 1000 tier benchmark when the cellx cells are disposed (hyperactiv's score improving to ~1600 from ~4500).

Sorry to bother you like this 😅